### PR TITLE
Allow routing from UDP port besides UART device

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ following:
 
 The `-b` switch above is used to set the UART baudrate. See more options with
 `mavlink-routerd --help`
+
+It's also possible to route mavlinks packets from any interface using:
+
+    $ mavlink-routerd -b 1500000 -e 192.168.7.1:14550 -e 127.0.0.1:14550  0.0.0.0:24550

--- a/comm.h
+++ b/comm.h
@@ -74,7 +74,7 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *ip, unsigned long port);
+    int open(const char *ip, unsigned long port, bool bind = false);
 
     struct sockaddr_in sockaddr;
 


### PR DESCRIPTION
Added `-u <udp_port>` option to allow mavlink_router to route from an
UDP port on *localhost*.
To keep consistence, UART device now must be informed via `-s UART`
argument. Note that one can't route from both at the same time.