### PR TITLE
Use __BASE_FILE__ for logging macro

### DIFF
--- a/log.h
+++ b/log.h
@@ -41,7 +41,7 @@ int log_internal(int level, int error,
     ({                                                                  \
          int _level = (level), _e = (error);                            \
          (log_get_max_level() >= LOG_PRI(_level))                       \
-            ? log_internal(_level, _e, __FILE__, __LINE__, __VA_ARGS__) \
+            ? log_internal(_level, _e, __BASE_FILE__, __LINE__, __VA_ARGS__) \
             : -abs(_e);                                                 \
         })
 


### PR DESCRIPTION
Using __FILE__ is not a problem on a dev environment, but it's
inconvenient when using distro-builders like yocto that build sources
out of tree.  It would use the following sring for logging:

	(../git/comm.cpp:333) Open 192.168.1.255:14550
	(../git/comm.cpp:333) Open 192.168.7.255:14550

While now we have:

	(comm.cpp:407) Open 192.168.7.255:14550
	(main.cpp:544) Open TCP 0.0.0.0:5760

__BASE_FILE__ is available on both GCC (tested with 6.3.1) and clang
(tested with 3.8.1)  so we can use it.