### PR TITLE
Conf files - v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,6 +121,8 @@ AM_LDFLAGS = \
 bin_PROGRAMS += mavlink-routerd
 mavlink_routerd_SOURCES = \
 	comm.h \
+	conf.cpp \
+	conf.h \
 	endpoint.cpp \
 	endpoint.h \
 	log.c \

--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ Port = 11000
 Note that `Port` is optional for endpoints whose `mode` is `normal`, as
 well as `baud` for UART endpoints.
 
+#### Conf dirs ####
+
+Besides default conf file, it's also possible to use a directory in where to
+put some extra configuration files. Files on such directory will be read in
+alphabetical order, and can add or override configurations found on previous
+files.
+
+By default, `/etc/mavlink-router/config.d` is the directory, but it can be
+overriden via `MAVLINK_ROUTER_CONF_DIR` environment variable, or via `-d`
+switch when running mavlink-routerd.
+
+Suppose default configuration file contents are the same of section above,
+an example of overriding configuration would be:
+
+```ini
+[Endpoint bravo]
+Baud = 115200
+```
+
+That would change `Endpoint bravo` baudrate to `115200`.
+
 ### Contributing ###
 
 Pull-requests are accepted on GitHub. Make sure to check coding style with the

--- a/README.md
+++ b/README.md
@@ -43,17 +43,52 @@ Install:
 To route mavlink packets from master `ttyS1` to 2 other UDP endpoints, do as
 following:
 
-    $ mavlink-routerd -b 1500000 -e 192.168.7.1:14550 -e 127.0.0.1:14550 /dev/ttyS1
+    $ mavlink-routerd -e 192.168.7.1:14550 -e 127.0.0.1:14550 /dev/ttyS1:1500000
 
-The `-b` switch above is used to set the UART baudrate. See more options with
-`mavlink-routerd --help`
+The `1500000` after colon above on `/dev/ttyS1:1500000` is used to set the
+UART baudrate. See more options with `mavlink-routerd --help`
 
 It's also possible to route mavlinks packets from any interface using:
 
-    $ mavlink-routerd -b 1500000 -e 192.168.7.1:14550 -e 127.0.0.1:14550  0.0.0.0:24550
+    $ mavlink-routerd -e 192.168.7.1:14550 -e 127.0.0.1:14550  0.0.0.0:24550
 
 mavlink-router also listens, by default, port 5760 for TCP connections. Any
 connection there will also receive routed packets.
+
+### Conf file ###
+
+It's also possible to use a .conf file to set options for mavlink-routerd.
+By default, mavlink-routerd looks for a file
+`/etc/mavlink-router/main.conf`. File location can be overriden via
+`MAVLINK_ROUTER_CONF_FILE` environment variable, or via `-c` switch when running
+mavlink-routerd.
+An example of conf file would be:
+
+```ini
+[General]
+tcp=5790
+report-stats=false
+
+[Endpoint alfa]
+Type = UDP
+Mode = Eavesdropping
+Address = 0.0.0.0
+Port = 10000
+
+[Endpoint bravo]
+Type = UART
+Device = /dev/tty0
+Baud = 52000
+
+[Endpoint charlie]
+Type = UDP
+Mode = Normal
+Address = 127.0.0.1
+Port = 11000
+```
+
+Note that `Port` is optional for endpoints whose `mode` is `normal`, as
+well as `baud` for UART endpoints.
 
 ### Contributing ###
 

--- a/TODO
+++ b/TODO
@@ -4,11 +4,7 @@
    the endpoint. If necessary we can allow clients to negotiate links to use
    shm or memfd
 
- - Add configuration file (INI format): mandating each endpoint to be written
-   to the command-line was an "easy to bootstrap" way for mavlink-router. However
-   it's not ideal since changing the endpoints involves changing the init scripts.
-   
-   We need to add a simple INI parser that has the configuration for the endpoints
+ - Allow drop-in override of configuration files
 
  - Add systemd service file
 

--- a/conf.cpp
+++ b/conf.cpp
@@ -1,0 +1,282 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "conf.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "log.h"
+#include "util.h"
+
+struct config {
+    char *key;
+    char *value;
+    struct config *next;
+};
+
+struct section {
+    char *name;
+    struct config *configs;
+    struct config *current_config;
+    struct section *next;
+};
+
+ConfFile::~ConfFile()
+{
+    struct section *section;
+    struct config *config;
+
+    section = _sections;
+    while (section) {
+        struct section *tmp = section;
+
+        config = section->configs;
+        while (config) {
+            struct config *tmp_config = config;
+            free(config->key);
+            // config->value is on the same allocation as config->key, no need to free it
+            config = config->next;
+            free(tmp_config);
+        }
+
+        free(section->name);
+        section = section->next;
+        free(tmp);
+    }
+}
+
+int ConfFile::parse_file()
+{
+    FILE *file;
+    char *entry = NULL;
+    int line = 0, ret = 0;
+    size_t n = 0;
+    ssize_t read;
+
+    assert(_filename);
+
+    file = fopen(_filename, "re");
+    if (!file) {
+        log_error_errno(errno, "Could not open conf file '%s' (%m)", _filename);
+        return -EIO;
+    }
+
+    while ((read = getline(&entry, &n, file)) >= 0) {
+        line++;
+
+        _trim(entry);
+
+        switch (entry[0]) {
+        case ';':
+        case '#':
+        case '\0':
+            // Discards comment or blank line
+            free(entry);
+            break;
+        case '[':
+            ret = _add_section(entry, line);
+            if (ret < 0) {
+                goto end;
+            }
+            break;
+        default:
+            ret = _add_config(entry, line);
+            if (ret < 0) {
+                goto end;
+            }
+        }
+
+        entry = NULL;
+    }
+
+    _current_section = nullptr;
+
+    if (!_sections || !_sections->configs) {
+        log_error("Invalid conf file %s", _filename);
+        return -EINVAL;
+    }
+
+end:
+    free(entry);
+    fclose(file);
+    return ret;
+}
+
+const char *ConfFile::first_section()
+{
+    _current_section = _sections;
+    return _current_section->name;
+}
+
+const char *ConfFile::next_section()
+{
+    if (!_current_section->next)
+        return NULL;
+
+    _current_section = _current_section->next;
+    return _current_section->name;
+}
+
+int ConfFile::_add_section(char *entry, int line)
+{
+    struct section *section;
+
+    char *end = strchr(entry, ']');
+    if (!end) {
+        log_error("On file %s: Line %d: Unfinished section name. Expected ']'", _filename, line);
+        return -EINVAL;
+    }
+
+    if (*(end + 1) != '\0') {
+        log_error("On file %s: Line %d: Unexpected characters after session name", _filename, line);
+        return -EINVAL;
+    }
+
+    // So section name is the string between '[]'
+    *entry = ' ';
+    *end = '\0';
+    _trim(entry);
+
+    // Ensure section is not duplicated. If it is,
+    // just make parser add on known section
+    section = _sections;
+    while (section) {
+        if (strcaseeq(section->name, entry)) {
+            _current_section = section;
+            free(entry);
+            return 0;
+        }
+        section = section->next;
+    }
+
+    // Section is new.
+    section = (struct section *)calloc(1, sizeof(struct section));
+    assert_or_return(section, -ENOMEM);
+
+    section->name = entry;
+    section->next = _sections;
+    _sections = section;
+
+    _current_section = section;
+
+    return 0;
+}
+
+int ConfFile::_add_config(char *entry, int line)
+{
+    char *equal_pos;
+    struct config *config;
+
+    if (!(equal_pos = strchr(entry, '='))) {
+        log_error("On file %s: Line %d: Missing '=' on config", _filename, line);
+        return -EINVAL;
+    }
+
+    if (equal_pos == entry) {
+        log_error("On file %s: Line %d: Missing name on config", _filename, line);
+        return -EINVAL;
+    }
+
+    if (equal_pos == (entry + strlen(entry) - 1)) {
+        log_error("On file %s: Line %d: Missing value on config", _filename, line);
+        return -EINVAL;
+    }
+
+    config = (struct config *)malloc(sizeof(struct config));
+    assert_or_return(config, -ENOMEM);
+
+    config->key = entry;
+    config->value = equal_pos + 1;
+    *equal_pos = '\0';
+
+    _trim(config->key);
+    _trim(config->value);
+
+    config->next = _current_section->configs;
+    _current_section->configs = config;
+
+    return 0;
+}
+
+const char *ConfFile::next_from_section(const char *section_name, const char *key)
+{
+    struct section *section;
+    struct config *config;
+
+    if (!_current_section)
+        _current_section = _sections;
+
+    if (!_current_section) {
+        return NULL;
+    }
+
+    if (!strcaseeq(section_name, _current_section->name)) {
+        section = _sections;
+
+        while (section) {
+            if (strcaseeq(section->name, section_name)) {
+                _current_section = section;
+                _current_section->current_config = NULL;
+                break;
+            }
+            section = section->next;
+        }
+
+        if (!section) {
+            return NULL;
+        }
+    }
+
+    if (!_current_section->current_config
+        || !strcaseeq(_current_section->current_config->key, key)) {
+        config = _current_section->configs;
+    } else {
+        config = _current_section->current_config->next;
+    }
+
+    while (config) {
+        if (strcaseeq(config->key, key)) {
+            _current_section->current_config = config;
+            return config->value;
+        }
+        config = config->next;
+    }
+
+    return NULL;
+}
+
+void ConfFile::_trim(char *str)
+{
+    char *s = str;
+    char *end;
+
+    while (isspace(*s))
+        s++;
+
+    end = s + strlen(s);
+    while (end != s && isspace(*(end - 1)))
+        end--;
+
+    *end = '\0';
+
+    memmove(str, s, end - s + 1);
+}

--- a/conf.h
+++ b/conf.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+class ConfFile {
+public:
+    ConfFile(const char *filename)
+        : _filename{filename} {};
+
+    ~ConfFile();
+
+    int parse_file();
+    const char *next_from_section(const char *section_name, const char *key);
+    const char *first_section();
+    const char *next_section();
+
+private:
+    const char *_filename;
+    struct section *_sections = nullptr;
+    struct section *_current_section = nullptr;
+
+    int _add_section(char *entry, int line);
+    int _add_config(char *entry, int line);
+    void _trim(char *str);
+};

--- a/main.cpp
+++ b/main.cpp
@@ -18,31 +18,35 @@
 
 #include <assert.h>
 #include <getopt.h>
+#include <limits.h>
 #include <stdio.h>
 #include <sys/stat.h>
 
 #include "comm.h"
+#include "conf.h"
 #include "endpoint.h"
 #include "log.h"
 #include "mainloop.h"
 #include "util.h"
 
 #define MAVLINK_TCP_PORT 5760
+#define DEFAULT_BAUDRATE 115200U
+#define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"
 
 static struct opt opt = {
-        .baudrate = 115200U,
         .ep_addrs = nullptr,
         .master_addrs = nullptr,
-        .tcp_port = MAVLINK_TCP_PORT,
-        .report_msg_statistics = false,
+        .uart_devices = nullptr,
+        .conf_file_name = nullptr,
+        .tcp_port = ULONG_MAX,
+        .report_msg_statistics = false
 };
 
 static void help(FILE *fp) {
     fprintf(fp,
             "%s [OPTIONS...] [<uart>|<udp_address>]\n\n"
-            "  <uart>                       UART device that will be routed\n"
+            "  <uart>                       UART device (<device>[:<baudrate>]) that will be routed\n"
             "  <udp_address>                UDP address (<ip>:<port>) that will be routed\n"
-            "  -b --baudrate <baudrate>     Use baudrate for UART\n"
             "  -e --endpoint <ip[:port]>    Add UDP endpoint to communicate port is optional\n"
             "                               and in case it's not given it starts in 14550 and\n"
             "                               continues increasing not to collide with previous\n"
@@ -51,6 +55,7 @@ static void help(FILE *fp) {
             "  -t --tcp-port                Port in which mavlink-router will listen for TCP\n"
             "                               connections. Pass 0 to disable TCP listening.\n"
             "                               Default port 5760\n"
+            "  -c --conf-file               .conf file with configurations for mavlink-router.\n"
             "  -h --help                    Print this message\n"
             , program_invocation_short_name);
 }
@@ -75,6 +80,25 @@ static unsigned long find_next_endpoint_port(const char *ip)
     return port;
 }
 
+static int split_on_colon(const char *str, char **base, unsigned long *number)
+{
+    char *colonstr;
+
+    *base = strdup(str);
+    colonstr = strchrnul(*base, ':');
+    *number = ULONG_MAX;
+
+    if (*colonstr != '\0') {
+        *colonstr = '\0';
+        if (safe_atoul(colonstr + 1, number) < 0) {
+            free(*base);
+            return -EINVAL;
+        }
+    }
+
+    return 0;
+}
+
 static void add_endpoint_address(struct endpoint_address **list, char *ip, long int port)
 {
     struct endpoint_address *e = (struct endpoint_address *)malloc(sizeof(*e));
@@ -90,11 +114,30 @@ static void add_endpoint_address(struct endpoint_address **list, char *ip, long 
     *list = e;
 }
 
-static int parse_argv(int argc, char *argv[], const char **uart, char **udp_addr, unsigned long *udp_port)
+static int add_uart_endpoint(struct uart_endpoint_device **list, char *uart_device,
+                             unsigned long baudrate)
+{
+    struct uart_endpoint_device *d = (struct uart_endpoint_device *)malloc(sizeof(*d));
+
+    if (!d) {
+        log_error_errno(errno, "Could not parse endpoint device: %m");
+        return -ENOMEM;
+    }
+
+    d->device = uart_device;
+    d->baudrate = baudrate;
+    d->next = *list;
+    *list = d;
+
+    return 0;
+}
+
+static int parse_argv(int argc, char *argv[])
 {
     static const struct option options[] = {
         { "baudrate",               required_argument,  NULL,   'b' },
         { "endpoints",              required_argument,  NULL,   'e' },
+        { "conf-file",               required_argument,  NULL,   'i' },
         { "report_msg_statistics",  no_argument,        NULL,   'r' },
         { "tcp-port",               required_argument,  NULL,   't' },
         { }
@@ -104,37 +147,23 @@ static int parse_argv(int argc, char *argv[], const char **uart, char **udp_addr
 
     assert(argc >= 0);
     assert(argv);
-    assert(uart);
 
-    *uart = NULL;
-
-    while ((c = getopt_long(argc, argv, "hb:e:rt:", options, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "he:rt:c:", options, NULL)) >= 0) {
         switch (c) {
         case 'h':
             help(stdout);
             return 0;
-        case 'b':
-            if (safe_atoul(optarg, &opt.baudrate) < 0) {
-                log_error("Invalid argument for baudrate = %s", optarg);
+        case 'e': {
+            char *ip;
+            unsigned long port;
+
+            if (split_on_colon(optarg, &ip, &port) < 0) {
+                log_error("Invalid port in argument: %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
-            break;
-        case 'e': {
-            char *ip = strdup(optarg);
-
-            char *portstr = strchrnul(ip, ':');
-            unsigned long port;
-            if (*portstr == '\0') {
+            if (port == ULONG_MAX) {
                 port = find_next_endpoint_port(ip);
-            } else {
-                *portstr = '\0';
-                if (safe_atoul(portstr + 1, &port) < 0) {
-                    log_error("Invalid port in argument: %s", optarg);
-                    free(ip);
-                    help(stderr);
-                    return -EINVAL;
-                }
             }
 
             add_endpoint_address(&opt.ep_addrs, ip, port);
@@ -152,6 +181,10 @@ static int parse_argv(int argc, char *argv[], const char **uart, char **udp_addr
             }
             break;
         }
+        case 'c': {
+            opt.conf_file_name = optarg;
+            break;
+        }
         case '?':
         default:
             help(stderr);
@@ -160,42 +193,31 @@ static int parse_argv(int argc, char *argv[], const char **uart, char **udp_addr
     }
 
     /* positional arguments */
-    if (optind + 1 > argc) {
-        log_error("Error parsing required argument %d %d", optind, argc);
-        help(stderr);
-        return -EINVAL;
-    }
-
     while (optind < argc) {
-        if (stat(argv[optind], &st) == -1 || !S_ISCHR(st.st_mode)) {
-            unsigned long port;
-            char *ip = strdup(argv[optind]);
+        // UDP and UART master endpoints are of the form:
+        // UDP: <ip>:<port> UART: <device>[:<baudrate>]
+        char *base;
+        unsigned long number;
 
-            char *portstr = strchrnul(ip, ':');
-            if (*portstr == '\0') {
-                log_error("Invalid argument for UDP address = %s. Please inform <address>:<port>",
-                          argv[optind]);
+        if (split_on_colon(argv[optind], &base, &number) < 0) {
+            log_error("Invalid argument %s", argv[optind]);
+            help(stderr);
+            return -EINVAL;
+        }
+
+        if (stat(base, &st) == -1 || !S_ISCHR(st.st_mode)) {
+            if (number == ULONG_MAX) {
+                log_error("Invalid argument for UDP port = %s", argv[optind]);
                 help(stderr);
-                free(ip);
+                free(base);
                 return -EINVAL;
-            } else {
-                *portstr = '\0';
-                if (safe_atoul(portstr + 1, &port) < 0) {
-                    log_error("Invalid argument for UDP port = %s", argv[optind]);
-                    help(stderr);
-                    free(ip);
-                    return -EINVAL;
-                }
             }
 
-            add_endpoint_address(&opt.master_addrs, ip, port);
+            add_endpoint_address(&opt.master_addrs, base, number);
         } else {
-            if (!*uart)
-                *uart = argv[optind];
-            else {
-                log_error("Cannot route from more than one UART!");
-                return -EINVAL;
-            }
+            int ret = add_uart_endpoint(&opt.uart_devices, base, number);
+            if (ret < 0)
+                return ret;
         }
         optind++;
     }
@@ -203,36 +225,187 @@ static int parse_argv(int argc, char *argv[], const char **uart, char **udp_addr
     return 2;
 }
 
+static const char *get_conf_file_name()
+{
+    char *s;
+
+    if (opt.conf_file_name)
+        return opt.conf_file_name;
+
+    s = getenv("MAVLINK_ROUTERD_CONF_FILE");
+    if (s)
+        return s;
+
+    return DEFAULT_CONFFILE;
+}
+
+static int parse_conf()
+{
+    const char *conf_file_name = get_conf_file_name();
+    const char *value, *section;
+    int ret;
+
+    ConfFile conf{conf_file_name};
+
+    ret = conf.parse_file();
+
+    if (ret < 0) {
+        // If there's no default conf file, everything is good
+        if (ret == -EIO && !strcmp(conf_file_name, DEFAULT_CONFFILE))
+            return 0;
+        return ret;
+    }
+
+    // This conflicting option is resolved by using command line one
+    value = conf.next_from_section("General", "tcp");
+    if (value && opt.tcp_port == ULONG_MAX && (safe_atoul(value, &opt.tcp_port) < 0)) {
+        log_error("On file %s: invalid argument for tcp-port = '%s'", conf_file_name, value);
+        return -EINVAL;
+    }
+
+    value = conf.next_from_section("General", "report-stats");
+    if (value) {
+        if (!strcasecmp(value, "true") || !strcmp(value, "1"))
+            opt.report_msg_statistics = true;
+    }
+
+    section = conf.first_section();
+    while (section) {
+        const char *type;
+
+        if (strncasecmp(section, "endpoint ", strlen("endpoint "))) {
+            section = conf.next_section();
+            continue;
+        }
+
+        type = conf.next_from_section(section, "type");
+        if (!type) {
+            log_error("On file %s: expected 'type' key for %s", conf_file_name, section);
+            return -EINVAL;
+        }
+
+        if (!strcasecmp(type, "uart")) {
+            // ********************* UART type ***********************
+            const char *baudstr, *device;
+            char *d;
+            unsigned long baud;
+
+            device = conf.next_from_section(section, "device");
+            if (!device) {
+                log_error("On file %s: expected 'device' key for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            baudstr = conf.next_from_section(section, "baud");
+            if (!baudstr) {
+                baud = DEFAULT_BAUDRATE;
+            } else if (safe_atoul(baudstr, &baud)) {
+                log_error("On file %s: invalid baudrate for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            // As mainloop frees this char*, we need to use something that can be freed
+            d = strdup(device);
+            if (!d) {
+                log_error_errno(errno, "On file %s: could not parse %s (%m)", conf_file_name,
+                                section);
+                return -ENOMEM;
+            }
+            ret = add_uart_endpoint(&opt.uart_devices, d, baud);
+            if (ret < 0) {
+                return ret;
+            }
+        } else if (!strcasecmp(type, "udp")) {
+            // ********************* UDP type ***********************
+            const char *addr, *portstr, *mode;
+            unsigned long port = ULONG_MAX;
+            struct endpoint_address **list;
+            char *c;
+
+            addr = conf.next_from_section(section, "address");
+            if (!addr) {
+                log_error("On file %s: expected 'address' key for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            mode = conf.next_from_section(section, "mode");
+            if (!mode) {
+                log_error("On file %s: expected 'mode' key for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            portstr = conf.next_from_section(section, "port");
+            if (portstr && safe_atoul(portstr, &port) < 0) {
+                log_error("On file %s: invalid port for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            if (!strcasecmp(mode, "normal")) {
+                list = &opt.ep_addrs;
+            } else if (!strcasecmp(mode, "eavesdropping")) {
+                list = &opt.master_addrs;
+            } else {
+                log_error("On file %s: unknown 'mode' key for %s", conf_file_name, section);
+                return -EINVAL;
+            }
+
+            // Eavesdroppoing (or master) udp endpoints need an explicit port
+            if (port == ULONG_MAX) {
+                if (list == &opt.master_addrs) {
+                    log_error("On file %s: expected 'port' key for %s", conf_file_name, section);
+                    return -EINVAL;
+                }
+                port = find_next_endpoint_port(addr);
+            }
+
+            // As mainloop frees this char*, we need to use something that can be freed
+            c = strdup(addr);
+            if (!c) {
+                log_error_errno(errno, "On file %s: could not parse %s (%m)", conf_file_name,
+                                section);
+                return -ENOMEM;
+            }
+            add_endpoint_address(list, c, port);
+        } else {
+            log_info("On file %s: Unknown type for %s", conf_file_name, section);
+        }
+
+        section = conf.next_section();
+    }
+
+    return 0;
+}
+
 int main(int argc, char *argv[])
 {
-    unsigned long udp_port = 0;
-    const char *uartstr = NULL;
-    char *udp_addr = NULL;
     Mainloop mainloop{};
 
     log_open();
 
-    if (parse_argv(argc, argv, &uartstr, &udp_addr, &udp_port) != 2)
+    if (parse_argv(argc, argv) != 2)
+        goto close_log;
+
+    if (parse_conf() < 0)
         goto close_log;
 
     if (mainloop.open() < 0)
         goto close_log;
 
-    if (!mainloop.add_endpoints(mainloop, uartstr, &opt))
+    if (opt.tcp_port == ULONG_MAX)
+        opt.tcp_port = MAVLINK_TCP_PORT;
+
+    if (!mainloop.add_endpoints(mainloop, &opt))
         goto close_log;
 
     mainloop.loop();
 
     mainloop.free_endpoints(&opt);
 
-    free(udp_addr);
-
     log_close();
 
     return 0;
 
 close_log:
-    free(udp_addr);
     log_close();
     return EXIT_FAILURE;
 }

--- a/mainloop.h
+++ b/mainloop.h
@@ -63,23 +63,29 @@ private:
     void _del_timeouts();
 };
 
-struct endpoint_address {
-    struct endpoint_address *next;
-    const char *ip;
-    unsigned long port;
-};
+enum endpoint_type { Uart, Udp, Unknown };
 
-struct uart_endpoint_device {
-    struct uart_endpoint_device *next;
-    const char *device;
-    long unsigned baudrate;
+struct endpoint_config {
+    struct endpoint_config *next;
+    char *name;
+    enum endpoint_type type;
+    union {
+        struct {
+            char *address;
+            long unsigned port;
+            bool eavesdropping;
+        };
+        struct {
+            char *device;
+            long unsigned baud;
+        };
+    };
 };
 
 struct opt {
-    struct endpoint_address *ep_addrs;
-    struct endpoint_address *master_addrs;
-    struct uart_endpoint_device *uart_devices;
+    struct endpoint_config *endpoints;
     const char *conf_file_name;
+    const char *conf_dir;
     unsigned long tcp_port;
     bool report_msg_statistics;
 };

--- a/mainloop.h
+++ b/mainloop.h
@@ -45,7 +45,7 @@ public:
     void del_timeout(Timeout *t);
 
     void free_endpoints(struct opt *opt);
-    bool add_endpoints(Mainloop &mainloop, const char *uartstr, struct opt *opt);
+    bool add_endpoints(Mainloop &mainloop, struct opt *opt);
 
     void print_statistics();
 
@@ -69,10 +69,17 @@ struct endpoint_address {
     unsigned long port;
 };
 
-struct opt {
+struct uart_endpoint_device {
+    struct uart_endpoint_device *next;
+    const char *device;
     long unsigned baudrate;
+};
+
+struct opt {
     struct endpoint_address *ep_addrs;
     struct endpoint_address *master_addrs;
+    struct uart_endpoint_device *uart_devices;
+    const char *conf_file_name;
     unsigned long tcp_port;
     bool report_msg_statistics;
 };


### PR DESCRIPTION
Changes from v1:
  - Accept `#` as a comment to Linuxfy a bit
  - New `strcasecmp` macro to compare strings, ignoring case
  - `null_check` macro is now `assert_or_return`.
  - New patch adding possibility to have a dir in which .conf files can be put, allowing one to add and override previous configuration. Files on this dir are read in alphabetical order - allowing one to chain overrides.
   -- This last patch involved some refactor - review it with care =D