### PR TITLE
Fix leaks on parse conf files code

### DIFF
--- a/conf.cpp
+++ b/conf.cpp
@@ -111,6 +111,7 @@ int ConfFile::parse_file()
     _current_section = nullptr;
 
     if (!_sections || !_sections->configs) {
+        free(entry);
         log_error("Invalid conf file %s", _filename);
         return -EINVAL;
     }


### PR DESCRIPTION
 - main.cpp: opendir and strdup result were leaking on early returns
 - main.cpp: # of files that can be parsed is limited - enforce limit
 - conf.cpp: getline result was leaking on early return