### PR TITLE
configure: allow different mavlink dialect to be used

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,24 +14,28 @@ AM_MAKEFLAGS = --no-print-directory
 GCC_COLORS ?= 'yes'
 export GCC_COLORS
 
-BUILT_SOURCES = include/mavlink/common/mavlink.h
+DIALECT=@DIALECT@
+
+BUILT_SOURCES = include/mavlink/$(DIALECT)/mavlink.h
+
+MAVLINK_XML=$(DIALECT).xml
 
 clean-local:
 	rm -rf $(top_builddir)/include/mavlink
 
-include/mavlink/common/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/common.xml
+include/mavlink/$(DIALECT)/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/$(MAVLINK_XML)
 	$(AM_V_GEN)python2 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
 		-o include/mavlink \
 		--lang C \
 		--wire-protocol 2.0 \
-		$(srcdir)/modules/mavlink/message_definitions/v1.0/common.xml
+		$(srcdir)/modules/mavlink/message_definitions/v1.0/$(MAVLINK_XML)
 
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
 	-I$(top_builddir) \
 	-I$(top_srcdir) \
 	-I$(top_builddir)/include/mavlink \
-	-I$(top_builddir)/include/mavlink/common \
+	-I$(top_builddir)/include/mavlink/$(DIALECT) \
 	-DSYSCONFDIR=\""$(sysconfdir)"\"
 
 AM_CFLAGS = \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Install:
     $ # or... to another root directory:
     $ make DESTDIR=/tmp/root/dir install
 
+#### Mavlink dialect ####
+
+By default, MAVlink Router uses `common` mavlink dialect.
+Optionally, it's possible to use `ardupilotmega` mavlink dialect. To do so,
+one needs to inform `ardupilotmega` to configure option `--with-dialect`:
+
+    $ ./configure --with-dialect=ardupilotmega
+
 ### Running ###
 
 To route mavlink packets from master `ttyS1` to 2 other UDP endpoints, do as

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,15 @@ AC_ARG_WITH([rootlibdir],
         [], [with_rootlibdir=$libdir])
 AC_SUBST([rootlibdir], [$with_rootlibdir])
 
+AC_ARG_WITH([dialect],
+            [AS_HELP_STRING([--with-dialect=common|ardupilotmega],[mavlink dialect to use [default=common]])],
+            [],
+            [with_dialect="common"])
+AS_IF([test $with_dialect != ardupilotmega -a $with_dialect != common ],
+      [AC_MSG_ERROR([invalid dialect $with_dialect. must be ´common´ or ´ardupilotmega´])],
+      [])
+AC_SUBST([DIALECT], [$with_dialect])
+
 #####################################################################
 # --enable-
 #####################################################################
@@ -88,4 +97,6 @@ AC_MSG_RESULT([
 
 	C compiler:		${CC}
 	C++ compiler:		${CXX}
+
+	Mavlink dialect:	${with_dialect}
 ])


### PR DESCRIPTION
This way, mavlink-router is able to understand different MAVLink
messages definitions. To do so, one needs to inform the different
`common.xml` file via MAVLINK_XML option to configure:

    $ ./configure MAVLINK_XML=path/to/common.xml