### PR TITLE
ULog: Restart it when initial header have problems

### DIFF
--- a/ulog.cpp
+++ b/ulog.cpp
@@ -338,12 +338,16 @@ void ULog::_logging_data_process(mavlink_logging_data_t *msg)
 
         if (msg->length < ULOG_HEADER_SIZE) {
             /* This should never happen */
-            log_error("ULog header is not complete");
+            log_error("ULog header is not complete, restarting ULog...");
+            stop();
+            start();
             return;
         }
 
         if (memcmp(magic, msg->data, sizeof(magic))) {
-            log_error("Invalid ULog Magic number");
+            log_error("Invalid ULog Magic number, restarting ULog...");
+            stop();
+            start();
             return;
         }
 


### PR DESCRIPTION
I was able to reproduce the 'Invalid ULog Magic number' once
and it keep printing this message forever so better restart
the ULog.