### PR TITLE
tcp endpoint: After reconnection, mavlink-router wasn't listening it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,14 @@ Port = 11000
 [TcpEndpoint delta]
 Address = 127.0.0.1
 Port = 25790
+RetryTimeout=10
 ```
 
 Note that `Port` is optional for endpoints whose `mode` is `normal`, as
 well as `baud` for UART endpoints.
+On TcpEndpoints, `RetryTimeout` is a time in seconds in which mavlink-router
+will try to reconnect a lost TCP connection. Default is 5 seconds, and setting
+it to zero disables reconnections.
 
 #### Conf dirs ####
 

--- a/mainloop.cpp
+++ b/mainloop.cpp
@@ -229,6 +229,8 @@ int Mainloop::_add_tcp_endpoint(TcpEndpoint *tcp)
     tcp_entry->endpoint = tcp;
     g_tcp_endpoints = tcp_entry;
 
+    add_fd(tcp->fd, tcp, EPOLLIN);
+
     return 0;
 }
 
@@ -244,8 +246,6 @@ void Mainloop::handle_tcp_connection()
 
     if (_add_tcp_endpoint(tcp) < 0)
         goto add_error;
-
-    add_fd(fd, tcp, EPOLLIN);
 
     log_debug("Accepted TCP connection on [%d]", fd);
     return;
@@ -388,7 +388,6 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct opt *opt)
                 log_error("Could not open %s:%ld", conf->address, conf->port);
                 return false;
             }
-            mainloop.add_fd(tcp->fd, tcp.get(), EPOLLIN);
             tcp.release();
             break;
         }


### PR DESCRIPTION
Missing addition of file descriptor to epoll. Fixed - now, every time
an endpoint is added to tcp endpoint list, it will automatically enroll
file descriptor on epoll.

Also, RetryTimeout property documented on README.