### PR TITLE
main: Fix wrong argument expansion

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -313,7 +313,7 @@ static int parse_argv(int argc, char *argv[])
     static const struct option options[] = {
         { "baudrate",               required_argument,  NULL,   'b' },
         { "endpoints",              required_argument,  NULL,   'e' },
-        { "conf-file",              required_argument,  NULL,   'i' },
+        { "conf-file",              required_argument,  NULL,   'c' },
         { "conf-dir" ,              required_argument,  NULL,   'd' },
         { "report_msg_statistics",  no_argument,        NULL,   'r' },
         { "tcp-port",               required_argument,  NULL,   't' },

--- a/main.cpp
+++ b/main.cpp
@@ -311,7 +311,6 @@ fail:
 static int parse_argv(int argc, char *argv[])
 {
     static const struct option options[] = {
-        { "baudrate",               required_argument,  NULL,   'b' },
         { "endpoints",              required_argument,  NULL,   'e' },
         { "conf-file",              required_argument,  NULL,   'c' },
         { "conf-dir" ,              required_argument,  NULL,   'd' },


### PR DESCRIPTION
It was converting `--conf-file` to `-i`, instead of `-c`