### PR TITLE
log: Stop using C++14 feature

### DIFF
--- a/logendpoint.cpp
+++ b/logendpoint.cpp
@@ -81,7 +81,7 @@ int LogEndpoint::_get_file(const char *extension, char *filename, size_t filenam
         return log_error_errno(errno, "Could not open log dir (%m)");
     }
     // Close dir when leaving function.
-    std::shared_ptr<void> defer(dir, [](auto p) { closedir(p); });
+    std::shared_ptr<void> defer(dir, [](DIR *p) { closedir(p); });
 
     i = _get_prefix(dir);
 


### PR DESCRIPTION
auto parameters on lambda function declaration is a C++14 feature. Not
all environments support it, though.