### PR TITLE
debug-log: Not log 'Network unreachable' errors

### DIFF
--- a/endpoint.cpp
+++ b/endpoint.cpp
@@ -501,7 +501,7 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
     ssize_t r = ::sendto(fd, pbuf->data, pbuf->len, 0,
                          (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (r == -1) {
-        if (errno != EAGAIN && errno != ECONNREFUSED)
+        if (errno != EAGAIN && errno != ECONNREFUSED && errno != ENETUNREACH)
             log_error_errno(errno, "Error sending udp packet (%m)");
         return -errno;
     };


### PR DESCRIPTION
They can be pretty common when no one is listening on one network.

Note, this is more of a temporary measure, a proper solution is coming.