### PR TITLE
conf file: Explain all possible configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,42 +64,7 @@ By default, mavlink-routerd looks for a file
 `/etc/mavlink-router/main.conf`. File location can be overriden via
 `MAVLINK_ROUTER_CONF_FILE` environment variable, or via `-c` switch when running
 mavlink-routerd.
-An example of conf file would be:
-
-```ini
-[General]
-#Mavlink-router serves on this TCP port
-TcpServerPort=5790
-ReportStats=false
-#Which mavlink dialect is being used. Can be `common`[default] or `ardupilotmega`
-MavlinkDialect=ardupilotmega
-
-[UdpEndpoint alfa]
-Mode = Eavesdropping
-Address = 0.0.0.0
-Port = 10000
-
-[UartEndpoint bravo]
-Device = /dev/tty0
-Baud = 52000
-
-[UdpEndpoint charlie]
-Mode = Normal
-Address = 127.0.0.1
-Port = 11000
-
-#Mavlink-router will connect to this TCP address
-[TcpEndpoint delta]
-Address = 127.0.0.1
-Port = 25790
-RetryTimeout=10
-```
-
-Note that `Port` is optional for endpoints whose `mode` is `normal`, as
-well as `baud` for UART endpoints.
-On TcpEndpoints, `RetryTimeout` is a time in seconds in which mavlink-router
-will try to reconnect a lost TCP connection. Default is 5 seconds, and setting
-it to zero disables reconnections.
+An example of conf file can be found on [examples/config.sample](examples/config.sample)
 
 #### Conf dirs ####
 
@@ -112,7 +77,7 @@ By default, `/etc/mavlink-router/config.d` is the directory, but it can be
 overriden via `MAVLINK_ROUTER_CONF_DIR` environment variable, or via `-d`
 switch when running mavlink-routerd.
 
-Suppose default configuration file contents are the same of section above,
+Suppose default configuration file defines an `UartEndpoint` using `Baud=56600`,
 an example of overriding configuration would be:
 
 ```ini

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -1,0 +1,115 @@
+# mavlink-router configuration file is composed of sections,
+# each section have some keys and values. They
+# are case insensitive, so `Key=Value` is the same as `key=value`.
+#
+# [This-is-a-section name-of-section]
+# ThisIsAKey=ThisIsAValuye
+#
+# Following specifications of expected sessions and key/values.
+#
+# Section [General]: This section doesn't have a name.
+#
+# Keys:
+#   TcpServerPort
+#       A numeric value defining in which port mavlink-router will
+#       listen for TCP connections. A zero value disables TCP listening.
+#       Default: 5760
+#
+#   ReportStats
+#       Boolean value <true> or <false> case insensitive, or <0> or <1>
+#       defining if traffic statistics should be reported.
+#       Default: false
+#
+#   MavlinkDialect
+#       One of <common> or <ardupilotmega>. Defines which MAVLink dialect
+#       is being used by flight stack, so mavlink-router can log
+#       appropiately.
+#       Default: common
+#
+#   Log
+#       Path to directory where to store flightstack log.
+#       No default value. If absent, no flightstack log will be stored.
+#
+#   LogDebugLevel
+#       One of <error>, <warning>, <info> or <debug>. Which debug log
+#       level is being used by mavlink-router, with <debug> being the
+#       most verbose.
+#       Default:<info>
+#
+# Section [UartEndpoint]: This section must have a name
+#
+# Keys:
+#   Device
+#       Path to UART device, like `/dev/ttyS0`
+#       No default value. Must be defined.
+#
+#   Baud
+#       Numeric value stating baudrate of UART device
+#       Default: 115200
+#
+# Section [UdpEndpoint]: This section must have a name
+#
+# Keys:
+#   Address
+#       If on `Normal` mode, IP to which mavlink-router will
+#       route messages to (and from). If on `Eavesdropping` mode,
+#       IP of interface to which mavlink-router will listen for
+#       incoming packets. In this case, `0.0.0.0` means that
+#       mavlink-router will listen on all interfaces.
+#       No dafault value. Must be defined.
+#
+#   Mode
+#       One of <normal> or <eavesdropping>. See `Address` for more
+#       information.
+#       No default value. Must be defined
+#
+#   Port
+#       Numeric value defining in which port mavlink-router will send
+#       packets (or listen for them).
+#       Default value: Increasing value, starting from 14550, when
+#       mode is `Normal`. Must be defined if on `Eavesdropping` mode.
+#
+# Section [TcpEndpoint]: This section must have a name
+#
+# Keys:
+#   Address:
+#       IP to which mavlink-router will connect to.
+#       No default value. Must be defined.
+#
+#   Port:
+#       Numeric value with port to which mavlink-router will connect to.
+#       No dafault value. Must be defined.
+#
+#   RetryTimeout:
+#       Numeric value defining how many seconds mavlink-router should wait
+#       to reconnect to IP in case of disconnection. A value of 0 disables
+#       reconnection.
+#       Default value: 5
+#
+# Following, an example of configuration file:
+[General]
+#Mavlink-router serves on this TCP port
+TcpServerPort=5790
+ReportStats=false
+#Which mavlink dialect is being used. Can be `common`[default] or `ardupilotmega`
+MavlinkDialect=ardupilotmega
+
+[UdpEndpoint alfa]
+Mode = Eavesdropping
+Address = 0.0.0.0
+Port = 10000
+
+[UartEndpoint bravo]
+Device = /dev/tty0
+Baud = 52000
+
+[UdpEndpoint charlie]
+Mode = Normal
+Address = 127.0.0.1
+Port = 11000
+
+#Mavlink-router will connect to this TCP address
+[TcpEndpoint delta]
+Address = 127.0.0.1
+Port = 25790
+RetryTimeout=10


### PR DESCRIPTION
Added a example of a config file, with a header that explain in details
all configurations.

Readme changed to point to this file.