### PR TITLE
config file: Name property about debug log level as DebugLogLevel

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -30,7 +30,7 @@
 #       Path to directory where to store flightstack log.
 #       No default value. If absent, no flightstack log will be stored.
 #
-#   LogDebugLevel
+#   DebugLogLevel
 #       One of <error>, <warning>, <info> or <debug>. Which debug log
 #       level is being used by mavlink-router, with <debug> being the
 #       most verbose.

--- a/main.cpp
+++ b/main.cpp
@@ -532,7 +532,7 @@ static int parse_conf(const char *conf_file_name)
         opt.logs_dir = strdup(value);
     }
 
-    value = conf.next_from_section("General", "LogDebugLevel");
+    value = conf.next_from_section("General", "DebugLogLevel");
     if (value) {
         int lvl = log_level_from_str(value);
         if (lvl == -EINVAL) {


### PR DESCRIPTION
It was being inconsistently called LogDebugLevel.