### PR TITLE
log: Aggregate some log messages that could flood output

### DIFF
--- a/endpoint.h
+++ b/endpoint.h
@@ -73,6 +73,8 @@ public:
     virtual int write_msg(const struct buffer *pbuf) = 0;
     virtual int flush_pending_msgs() = 0;
 
+    void log_aggregate(int interval);
+
     uint8_t get_trimmed_zeros(const struct buffer *buffer);
 
     uint8_t get_system_id() { return _system_id; }
@@ -108,7 +110,7 @@ protected:
     } _stat;
 
     const bool _crc_check_enabled;
-
+    uint32_t _incomplete_msgs = 0;
     uint8_t _system_id = 0;
 
     static Mainloop *_mainloop;

--- a/mainloop.h
+++ b/mainloop.h
@@ -23,6 +23,8 @@
 #include "timeout.h"
 #include "ulog.h"
 
+#define LOG_AGGREGATE_INTERVAL 5
+
 struct endpoint_entry {
     struct endpoint_entry *next;
     TcpEndpoint *endpoint;
@@ -56,15 +58,21 @@ private:
     endpoint_entry *g_tcp_endpoints;
     Endpoint **g_endpoints;
     int g_tcp_fd;
+    int _log_aggregate_interval = LOG_AGGREGATE_INTERVAL;
     LogEndpoint *_log_endpoint = nullptr;
 
     Timeout *_timeouts = nullptr;
+
+    struct {
+        uint32_t msg_to_unknown = 0;
+    } _errors_aggregate;
 
     int tcp_open(unsigned long tcp_port);
     void _del_timeouts();
     int _add_tcp_endpoint(TcpEndpoint *tcp);
     void _add_tcp_retry(TcpEndpoint *tcp);
     bool _retry_timeout_cb(void *data);
+    bool _log_aggregate_timeout(void *data);
 };
 
 enum endpoint_type { Tcp, Uart, Udp, Unknown };


### PR DESCRIPTION
To avoiding flooding output, some error/warning messages on routing
code path were increased to debug, and an aggregator sums how many of
those error code path were taken, printing the aggregate, if any,
each five seconds.

This way, we don't lose track of these code paths without flooding
output. As original messages are still there with debug log level, if any
interest on such situations appear, one can simply raise debug log level
to `debug` and get more datails.