### PR TITLE
TCP Endpoints: Report stats

### DIFF
--- a/endpoint.cpp
+++ b/endpoint.cpp
@@ -297,7 +297,7 @@ void Endpoint::print_statistics()
 {
     const uint32_t read_total = _stat.read.total == 0 ? 1 : _stat.read.total;
 
-    printf("Endpoint %s sysid: %u {", _name, _system_id);
+    printf("Endpoint %s [%d] sysid: %u {", _name, fd, _system_id);
     printf("\n\tReceived messages {");
     printf("\n\t\tCRC error: %u %u%% %luKBytes", _stat.read.crc_error,
            (_stat.read.crc_error * 100) / read_total, _stat.read.crc_error_bytes / 1000);

--- a/mainloop.cpp
+++ b/mainloop.cpp
@@ -322,6 +322,9 @@ void Mainloop::print_statistics()
 {
     for (Endpoint **e = g_endpoints; *e != nullptr; e++)
         (*e)->print_statistics();
+
+    for (auto *t = g_tcp_endpoints; t; t = t->next)
+        t->endpoint->print_statistics();
 }
 
 static bool _print_statistics_timeout_cb(void *data)


### PR DESCRIPTION
mavlink-router was not reporting stats of connected TCP endpoints.

Also, added endpoint filedescriptor on stats, as this helps identifiying
endpoints.