### PR TITLE
log: Add `auto` dialect, that will guess autopilot MAVLink dialect

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,8 @@ AM_LDFLAGS = \
 
 bin_PROGRAMS += mavlink-routerd
 mavlink_routerd_SOURCES = \
+	autolog.cpp \
+	autolog.h \
 	binlog.cpp \
 	binlog.h \
 	comm.h \

--- a/autolog.cpp
+++ b/autolog.cpp
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "autolog.h"
+
+#include "binlog.h"
+#include "log.h"
+#include "ulog.h"
+
+int AutoLog::write_msg(const struct buffer *buffer)
+{
+    if (_logger != nullptr) {
+        return _logger->write_msg(buffer);
+    }
+
+    const bool mavlink2 = buffer->data[0] == MAVLINK_STX;
+    uint32_t msg_id;
+    uint8_t *payload;
+
+    if (mavlink2) {
+        struct mavlink_router_mavlink2_header *hdr
+            = (struct mavlink_router_mavlink2_header *)buffer->data;
+        msg_id = hdr->msgid;
+        payload = buffer->data + sizeof(*hdr);
+    } else {
+        struct mavlink_router_mavlink1_header *hdr
+            = (struct mavlink_router_mavlink1_header *)buffer->data;
+        msg_id = hdr->msgid;
+        payload = buffer->data + sizeof(*hdr);
+    }
+
+    /* We check autopilot on heartbeat */
+    if (msg_id == MAVLINK_MSG_ID_HEARTBEAT) {
+        uint8_t autopilot = payload[5];
+        log_debug("Got autopilot %u from heartbeat", autopilot);
+        if (autopilot == MAV_AUTOPILOT_PX4) {
+            _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir));
+            _logger->start();
+        } else if (autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir));
+            _logger->start();
+        } else {
+            log_warning("Unidentified autopilot, cannot start flight stack logging");
+        }
+    }
+
+    return buffer->len;
+}
+
+void AutoLog::stop()
+{
+    if (_logger)
+        _logger->stop();
+
+    _system_id = 0;
+}
+
+bool AutoLog::start()
+{
+    _system_id = LOG_ENDPOINT_SYSTEM_ID;
+
+    return true;
+}

--- a/autolog.h
+++ b/autolog.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+
+#include "endpoint.h"
+#include "logendpoint.h"
+
+class AutoLog : public LogEndpoint {
+public:
+    AutoLog(const char *logs_dir)
+        : LogEndpoint{logs_dir}
+    {
+    }
+
+    int write_msg(const struct buffer *pbuf) override;
+    int flush_pending_msgs() override { return -ENOSYS; }
+
+    bool start() override;
+    void stop() override;
+
+protected:
+    ssize_t _read_msg(uint8_t *buf, size_t len) { return 0; }
+
+    // These functions should never be called
+    const char *_get_logfile_extension() override { return ""; };
+    bool _start_timeout() override { return true; };
+
+private:
+    std::unique_ptr<LogEndpoint> _logger;
+};

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -21,10 +21,11 @@
 #       Default: false
 #
 #   MavlinkDialect
-#       One of <common> or <ardupilotmega>. Defines which MAVLink dialect
-#       is being used by flight stack, so mavlink-router can log
-#       appropiately.
-#       Default: common
+#       One of <auto>, <common> or <ardupilotmega>. Defines which MAVLink
+#       dialect is being used by flight stack, so mavlink-router can log
+#       appropiately. If <auto>, mavlink-router will try to decide based
+#       on heartbeat received from flight stack.
+#       Default: auto
 #
 #   Log
 #       Path to directory where to store flightstack log.

--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,7 @@ static struct options opt = {
         .report_msg_statistics = false,
         .logs_dir = nullptr,
         .debug_log_level = LOG_INFO,
-        .mavlink_dialect = Common
+        .mavlink_dialect = Auto
 };
 
 static void help(FILE *fp) {
@@ -515,7 +515,9 @@ static int parse_conf(const char *conf_file_name)
 
     value = conf.next_from_section("General", "MavlinkDialect");
     if (value) {
-        if (strcaseeq(value, "common")) {
+        if (strcaseeq(value, "auto")) {
+            opt.mavlink_dialect = Auto;
+        } else if (strcaseeq(value, "common")) {
             opt.mavlink_dialect = Common;
         } else if (strcaseeq(value, "ardupilotmega")) {
             opt.mavlink_dialect = Ardupilotmega;

--- a/mainloop.cpp
+++ b/mainloop.cpp
@@ -24,6 +24,7 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
+#include "autolog.h"
 #include "log.h"
 #include "util.h"
 
@@ -402,10 +403,12 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         g_tcp_fd = tcp_open(opt->tcp_port);
 
     if (opt->logs_dir) {
-        if (opt->mavlink_dialect == Common) {
+        if (opt->mavlink_dialect == Ardupilotmega) {
+            _log_endpoint = new BinLog(opt->logs_dir);
+        } else if (opt->mavlink_dialect == Common) {
             _log_endpoint = new ULog(opt->logs_dir);
         } else {
-            _log_endpoint = new BinLog(opt->logs_dir);
+            _log_endpoint = new AutoLog(opt->logs_dir);
         }
         g_endpoints[i] = _log_endpoint;
     }

--- a/mainloop.h
+++ b/mainloop.h
@@ -68,7 +68,7 @@ private:
 };
 
 enum endpoint_type { Tcp, Uart, Udp, Unknown };
-enum mavlink_dialect { Common, Ardupilotmega };
+enum mavlink_dialect { Auto, Common, Ardupilotmega };
 
 struct endpoint_config {
     struct endpoint_config *next;


### PR DESCRIPTION
This new MavlinkDialect option will identify flight stack MAVLink
dialect based on heartbeat.

This option is the new default, so people aren't expected to normally
deal with this setting.