### PR TITLE
Component id is back

### DIFF
--- a/endpoint.h
+++ b/endpoint.h
@@ -89,15 +89,19 @@ public:
 
     uint8_t get_trimmed_zeros(const struct buffer *buffer);
 
-    uint8_t get_system_id() { return _system_id; }
+    bool has_sys_id(unsigned sysid);
+    bool has_sys_comp_id(unsigned sysid, unsigned compid);
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid);
 
     struct buffer rx_buf;
     struct buffer tx_buf;
 
 protected:
-    virtual int read_msg(struct buffer *pbuf, int *target_system);
+    virtual int read_msg(struct buffer *pbuf, int *target_system, int *target_compid,
+                         uint8_t *src_sysid, uint8_t *src_compid);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
+    void _add_sys_comp_id(uint16_t sys_comp_id);
 
     const char *_name;
     size_t _last_packet_len = 0;
@@ -121,7 +125,7 @@ protected:
 
     const bool _crc_check_enabled;
     uint32_t _incomplete_msgs = 0;
-    uint8_t _system_id = 0;
+    std::vector<uint16_t> _sys_comp_ids;
 };
 
 class UartEndpoint : public Endpoint {
@@ -136,7 +140,8 @@ public:
     int add_speeds(std::vector<unsigned long> baudrates);
 
 protected:
-    int read_msg(struct buffer *pbuf, int *target_sysid) override;
+    int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
+                 uint8_t *src_compid) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:

--- a/logendpoint.cpp
+++ b/logendpoint.cpp
@@ -45,7 +45,8 @@ void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
     };
 
     buffer.len = mavlink_msg_to_send_buffer(data, msg);
-    Mainloop::get_instance().route_msg(&buffer, target_sysid, msg->sysid);
+    Mainloop::get_instance().route_msg(&buffer, target_sysid, MAV_COMP_ID_ALL, msg->sysid,
+                                       msg->compid);
 
     _stat.read.total++;
     _stat.read.handled++;

--- a/logendpoint.h
+++ b/logendpoint.h
@@ -42,6 +42,7 @@ protected:
     const char *_logs_dir;
     const int _target_system_id = LOG_ENDPOINT_TARGET_SYSTEM_ID;
     int _file = -1;
+    uint8_t _system_id;
 
     Timeout *_logging_start_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;

--- a/mainloop.h
+++ b/mainloop.h
@@ -35,7 +35,8 @@ public:
     int mod_fd(int fd, void *data, int events);
     int remove_fd(int fd);
     void loop();
-    void route_msg(struct buffer *buf, int target_sysid, int sender_sysid);
+    void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
+                   int sender_compid);
     void handle_read(Endpoint *e);
     void handle_canwrite(Endpoint *e);
     void handle_tcp_connection();

--- a/tests/routing_test.py
+++ b/tests/routing_test.py
@@ -63,6 +63,7 @@ class MavlinkSender(Thread):
             if msg is not None:
                 if msg.target_system == 0:
                     continue  # Just discard any broadcast ping we may receive
+
                 if self.targetSysId != 0 and msg.get_srcSystem(
                 ) != self.targetSysId:
                     log("Received unexpected response from %d/%d - current target: %d/%d"
@@ -125,14 +126,14 @@ if __name__ == "__main__":
     proc = subprocess.Popen(
         [
             "./mavlink-routerd", "-e", "127.0.0.1:10100", "-e",
-            "127.0.0.1:10101", "127.0.0.1:10000", "127.0.0.1:10001"
+            "127.0.0.1:10101", "127.0.0.1:10000"
         ],
         stderr=sys.stdout.fileno(),
         stdout=sys.stdout.fileno())
 
     # Two senders: one send to all (target 0). The other sends to target 100
     sender0 = MavlinkSender("sender0", 10000, 1, 1, 0, 0)
-    sender100 = MavlinkSender("sender100", 10001, 2, 1, 100, 1)
+    sender100 = MavlinkSender("sender100", 10000, 2, 1, 100, 1)
 
     # Two receivers.
     receiver100 = MavlinkReceiver("receiver100", 10100, 100, 0)
@@ -178,5 +179,7 @@ if __name__ == "__main__":
 
     if functools.reduce((lambda p, q: p and q), results):
         log("Routing test OK")
+        sys.exit(0)
     else:
         log("Routing test FAILED. See previous output for more information")
+        sys.exit(1)


### PR DESCRIPTION
mavros uses component_id on mavlink messages, so time to handle them again.

Note that this is a dangerous PR, review with care =D

As I've also updated tests, `make check` itself may be wrong, so, review with care²