### PR TITLE
Fix buffer overflow in ulog and binlog

### DIFF
--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -97,11 +97,20 @@ int BinLog::write_msg(const struct buffer *buffer)
         return buffer->len;
     }
 
+    const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(msg_id);
+    if (!msg_entry) {
+        return buffer->len;
+    }
+
+    if (payload_len > msg_entry->msg_len) {
+        payload_len = msg_entry->msg_len;
+    }
+
     uint8_t *payload;
 
     if (mavlink2) {
         payload = buffer->data + sizeof(struct mavlink_router_mavlink2_header);
-        trimmed_zeros = get_trimmed_zeros(buffer);
+        trimmed_zeros = get_trimmed_zeros(msg_entry, buffer);
     } else {
         payload = buffer->data + sizeof(struct mavlink_router_mavlink1_header);
         trimmed_zeros = 0;

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -389,18 +389,13 @@ void Endpoint::print_statistics()
     printf("\n}\n");
 }
 
-uint8_t Endpoint::get_trimmed_zeros(const struct buffer *buffer)
+uint8_t Endpoint::get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry, const struct buffer *buffer)
 {
     struct mavlink_router_mavlink2_header *msg
         = (struct mavlink_router_mavlink2_header *)buffer->data;
-    const mavlink_msg_entry_t *msg_entry;
 
     /* Only MAVLink 2 trim zeros */
     if (buffer->data[0] != MAVLINK_STX)
-        return 0;
-
-    msg_entry = mavlink_get_msg_entry(msg->msgid);
-    if (!msg_entry)
         return 0;
 
     /* Should never happen but if happens it will cause stack overflow */

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -87,7 +87,7 @@ public:
 
     void log_aggregate(unsigned int interval_sec);
 
-    uint8_t get_trimmed_zeros(const struct buffer *buffer);
+    uint8_t get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry, const struct buffer *buffer);
 
     bool has_sys_id(unsigned sysid);
     bool has_sys_comp_id(unsigned sys_comp_id);

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -125,11 +125,20 @@ int ULog::write_msg(const struct buffer *buffer)
         return buffer->len;
     }
 
+    const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(msg_id);
+    if (!msg_entry) {
+        return buffer->len;
+    }
+
+    if (payload_len > msg_entry->msg_len) {
+        payload_len = msg_entry->msg_len;
+    }
+
     uint8_t *payload;
 
     if (mavlink2) {
         payload = buffer->data + sizeof(struct mavlink_router_mavlink2_header);
-        trimmed_zeros = get_trimmed_zeros(buffer);
+        trimmed_zeros = get_trimmed_zeros(msg_entry, buffer);
     } else {
         payload = buffer->data + sizeof(struct mavlink_router_mavlink1_header);
         trimmed_zeros = 0;


### PR DESCRIPTION
This should fix the buffer overflow reported here https://github.com/01org/mavlink-router/issues/97#issuecomment-312353368