### PR TITLE
Use gnu++11 to handle fallthrough warning

### DIFF
--- a/src/common/macro.h
+++ b/src/common/macro.h
@@ -25,16 +25,6 @@
 #define _pure_ __attribute__((pure))
 #define _packed_ __attribute__((packed))
 
-#ifdef __has_cpp_attribute
-#if __has_cpp_attribute(fallthrough)
-#define _fall_through_ [[fallthrough]]
-#endif
-#endif
-
-#ifndef _fall_through_
-#define _fall_through_
-#endif
-
 #define IOVEC_SET_STRING(i, s)          \
     do {                                \
         struct iovec *_i = &(i);        \

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -175,8 +175,8 @@ int ULog::write_msg(const struct buffer *buffer)
         ack.target_system = _target_system_id;
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
-        /* no break needed, message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        _fall_through_;
+        /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
+        [[gnu::fallthrough]];
     }
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {


### PR DESCRIPTION
GCC 7 turned the fallthrough warning on by default. These are the ways
to turn them handle them on the cases it should fallthrough:

    switch (cond) {
    case 1:
        bar (1);
        __attribute__ ((fallthrough)); // C and C++03
    case 2:
        bar (2);
        [[gnu::fallthrough]]; // C++11 and C++14
    case 3:
        bar (3);
        [[fallthrough]]; // C++17 and above
    /* ... */
    }

More info: https://dzone.com/articles/implicit-fallthrough-in-gcc-7
And it does work with clang as well.