### PR TITLE
endpoint: don't send msg back to the same endpoint

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -320,8 +320,9 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
         }
     }
 
-    // This endpoint sent the message, and there's no other sys_comp_id: reject msg
-    if (has_sys_comp_id(src_sysid, src_compid) && _sys_comp_ids.size() == 1)
+    // This endpoint sent the message, we don't want to send it back over the
+    // same channel to avoid loops: reject
+    if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
     // Message is broadcast on sysid: accept msg


### PR DESCRIPTION
If an endpoint is sending a packet through a channel and there are more
components IDs on the same endpoint, mavlink-router would send back any
message through the same channel.  It's never the expected behavior to
receive the message reflected back and there's no way to the other end
to deal with it. Exception would be of course check the destination
sysid/compid, but those may not be present.

This also changes the behavior if the same vehicle/component is
connected through multiple endpoints on mavlink-router, each of them
having more components. mavlink-router will now drop the packet do avoid
loops.

This is an alternative to the fix provided in
https://github.com/01org/mavlink-router/pull/113 and should fix the
issue in https://github.com/01org/mavlink-router/issues/107.